### PR TITLE
Ability to limit number of unique metrics per app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 maru.sh
 send.sh
+*.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM golang:1.7.4-alpine
+FROM golang:1.12-alpine
 RUN apk update
 RUN apk add openssl ca-certificates git
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
-COPY . /usr/src/app
 RUN go get "gopkg.in/mcuadros/go-syslog.v2"
-RUN go get "github.com/influxdata/influxdb/client/v2"
+RUN go get "github.com/lib/pq"
+COPY . /usr/src/app
 RUN go build main.go
 CMD ["/usr/src/app/main"]
 EXPOSE 9000

--- a/README.md
+++ b/README.md
@@ -1,0 +1,126 @@
+# Metrics Syslog Collector
+
+Add custom metrics to Influx/OpenTSDB via remote syslog
+
+## Syslog Format
+
+Syslog messages must be formatted according to `RFC5424` and sent via TCP. 
+
+The message of the syslog should have the following format:
+
+`type#metric.name=value`
+
+Type can be "measure", "sample", or "count"
+
+`metric.name` is a dot delimited description of the metric. The exact name is up to you and does not need to contain the Akkeris app name (that will be added automatically)
+
+Examples:
+- `measure#client.get=1ms`
+- `sample#db.size=100MB`
+- `count#email.sent=1`
+
+## Requirements
+
+Metrics Syslog Collector has two major requirements - a Postgres database and an OpenTSDB compatible server (i.e. influxdb)
+
+## Environment Variables
+
+| Name                  | Description                                                       | Required  |
+| --------------------- | ----------------------------------------------------------------- | --------- |
+| DATABASE_URL          | URL connection string for a Postgres database                     | Required  |
+| DEBUG                 | Set to "true" to print out additional degugging info              | Optional  |
+| OPENTSDB_IP           | IP address of the OpenTSDB compatible server to send metrics to   | Required  |
+| PORT                  | Network port to listen on                                         | Required  |
+| UNIQUE_METRIC_LIMIT   | How many metrics should be allowed per app - default is 200       | Optional  |
+
+## Running
+
+Docker:
+
+```shell
+$ docker build -t metrics-syslog-collector .
+$ docker run --env-file config.env -p 9000:9000 metrics-syslog-collector
+```
+
+Locally:
+
+```shell
+$ source config.env
+$ go run main.go
+```
+
+## Example
+
+We do not have automated tests for this yet. However, it is possible to see how the app works by doing the following:
+
+_(Note: these instructions were created using MacOS)_
+
+### 1. Install influxdb and enable opentsdb
+
+First, install influxdb:
+```shell
+$ brew install influxdb
+```
+
+Modify the influx configuration file:
+```
+$ vi /usr/local/etc/influxdb.conf
+```
+
+Find the `[[opentsdb]]` section and make the following changes to enable opentsdb:
+```
+489|  [[opentsdb]]
+490|    enabled = true
+491|    bind-address = ":4242"
+492|    database = "opentsdb"
+```
+
+Start the influx service:
+```shell
+$ influxd -config /usr/local/etc/influxdb.conf
+```
+
+### 2. Install postgres and create a new database
+
+```shell
+$ brew install postgresql
+$ brew services start postgresql
+$ createdb metrics-syslog-collector
+```
+
+### 3. Start the Metrics Syslog Collector
+
+Get your environment variables ready and put them in a file (`config.env`):
+```
+export DATABASE_URL=postgres://[YOUR USER NAME]@127.0.0.1:5432/metrics-syslog-collector?sslmode=disable
+export DEBUG=true
+export OPENTSDB_IP=127.0.0.1:4242
+export PORT=9000
+```
+_(Note: Be sure to replace [YOUR USER NAME] with your account username)_
+
+Now, you can start the application:
+```shell
+$ source config.env
+$ go run main.go
+```
+
+### 4. Send syslog message to Metrics Syslog Collector
+
+There are a few ways to do this, but on MacOS, it's easiest to use Docker. Open up a new shell and start up a Debian image:
+
+```shell
+$ docker run --rm -it debian /bin/bash
+
+$ logger -n host.docker.internal -P 9000 -t myapp -T "count#test=1"
+```
+
+You should see some chatter on the terminal window with Metrics Syslog Collector. 
+
+### 5. Query Influx
+
+Now, we can query Influx to see if the data was sent successfully:
+
+```shell
+$ curl http://127.0.0.1:8086/query\?db\=opentsdb\&q\=SHOW%20MEASUREMENTS
+```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Metrics Syslog Collector has two major requirements - a Postgres database and an
 | DEBUG                 | Set to "true" to print out additional degugging info              | Optional  |
 | OPENTSDB_IP           | IP address of the OpenTSDB compatible server to send metrics to   | Required  |
 | PORT                  | Network port to listen on                                         | Required  |
-| UNIQUE_METRIC_LIMIT   | How many metrics should be allowed per app - default is 200       | Optional  |
+| UNIQUE_METRIC_LIMIT   | How many metrics should be allowed per app - default is 100       | Optional  |
 
 ## Running
 

--- a/create.sql
+++ b/create.sql
@@ -1,0 +1,13 @@
+do $$
+begin
+
+create table if not exists app_metrics(
+  app text not null,
+  metric text not null,
+  created_at timestamptz not null default now(),
+  deleted boolean not null default false,
+  constraint PK primary key (app, metric)
+);
+
+end
+$$;

--- a/main.go
+++ b/main.go
@@ -1,95 +1,195 @@
 package main
 
 import (
-    "fmt"
-    "gopkg.in/mcuadros/go-syslog.v2"
-    "net"
-    "os"
-    "regexp"
-    "strconv"
-    "strings"
-    "time"
+	"database/sql"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	_ "github.com/lib/pq" //driver
+	"gopkg.in/mcuadros/go-syslog.v2"
 )
 
+var conn net.Conn
+var db *sql.DB
+
+var uniqueMetricLimit int
+
+const defaultMetricLimit int = 100
+
+func initDB() (err error) {
+	var dberr error
+	db, dberr = sql.Open("postgres", os.Getenv("DATABASE_URL"))
+	if dberr != nil {
+		return dberr
+	}
+	db.SetMaxIdleConns(4)
+	db.SetMaxOpenConns(20)
+
+	buf, err := ioutil.ReadFile("./create.sql")
+	if err != nil {
+		log.Println("Error: Unable to run migration scripts, could not load create.sql.")
+		return err
+	}
+
+	_, err = db.Exec(string(buf))
+	if err != nil {
+		log.Println("Error: Unable to run migration scripts, execution failed.")
+		return err
+	}
+
+	return nil
+}
+
+// checkMetric - Make sure that the app reporting the metric hasn't reached its unique metric limit
+func checkMetric(app string, metric string) bool {
+	// If in doubt (i.e. error returned) just send the metric to Influx
+
+	// Does metric exist in the database?
+	var exists bool
+	err := db.QueryRow("select exists(select * from app_metrics where app = $1 and metric = $2 and deleted = 'f')", app, metric).Scan(&exists)
+	if err != nil {
+		fmt.Println(err)
+		exists = true
+	}
+
+	if exists {
+		return true
+	}
+
+	// Metric does not exist in the database, need to make sure the app is under the uniqueMetricLimit
+	var metricCount int
+	err = db.QueryRow("select count(*) from app_metrics where app = $1 and deleted = 'f'", app).Scan(&metricCount)
+	if err != nil {
+		fmt.Println(err)
+		return true
+	}
+
+	if metricCount < uniqueMetricLimit {
+		_, err := db.Exec("insert into app_metrics(app, metric) values($1, $2)", app, metric)
+		if err != nil {
+			fmt.Println(err)
+		}
+		return true
+	}
+
+	if os.Getenv("DEBUG") == "true" {
+		fmt.Println("Did not send metric " + metric + " to influx for app " + app + ": Unique metric limit reached")
+	}
+	return false
+}
+
+func sendMetric(v []string, t map[string]string, message string, tags [][]string) {
+	var finalval string
+	finalval = v[3]
+	if v[4] == "MB" && strings.Contains(message, "[metrics]") {
+		val, err := strconv.ParseFloat(v[3], 64)
+		if err != nil {
+			fmt.Println(err)
+		}
+		finalval = strconv.FormatFloat(val*1048576, 'f', -1, 64)
+	} else if v[4] == "GB" && strings.Contains(message, "[metrics]") {
+		val, err := strconv.ParseFloat(v[3], 64)
+		if err != nil {
+			fmt.Println(err)
+		}
+		finalval = strconv.FormatFloat(val*1073741824, 'f', -1, 64)
+	} else if v[4] == "KB" && strings.Contains(message, "[metrics]") {
+		val, err := strconv.ParseFloat(v[3], 64)
+		if err != nil {
+			fmt.Println(err)
+		}
+		finalval = strconv.FormatFloat(val*1024, 'f', -1, 64)
+	} else {
+		finalval = v[3]
+	}
+	for _, tag := range tags {
+		t[tag[1]] = tag[2]
+	}
+	t["metric"] = v[2]
+	value, _ := strconv.ParseFloat(finalval, 64)
+	fields := map[string]interface{}{
+		"value": value,
+	}
+	tsdbmetric := v[1] + "." + t["metric"]
+	tsdbtags := "app=" + t["app"]
+	for _, tagelement := range tags {
+		tsdbtags = tsdbtags + " " + tagelement[1] + "=" + tagelement[2]
+	}
+	tsdbvalue := fields["value"].(float64)
+	s := strconv.FormatFloat(tsdbvalue, 'f', -1, 64)
+	timestamp := strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10)
+	put := "put " + tsdbmetric + " " + timestamp + " " + s + " " + tsdbtags + "\n"
+	if os.Getenv("DEBUG") == "true" {
+		fmt.Println(put)
+	}
+	fmt.Fprintf(conn, put)
+}
+
 func main() {
+	var err error
+	conn, err = net.Dial("tcp", os.Getenv("OPENTSDB_IP"))
+	if err != nil {
+		fmt.Println("dial error:", err)
+		return
+	}
 
-    conn, err := net.Dial("tcp", os.Getenv("OPENTSDB_IP"))
-    if err != nil {
-        fmt.Println("dial error:", err)
-        return
-    }
+	channel := make(syslog.LogPartsChannel)
+	handler := syslog.NewChannelHandler(channel)
 
-    channel := make(syslog.LogPartsChannel)
-    handler := syslog.NewChannelHandler(channel)
+	server := syslog.NewServer()
+	server.SetFormat(syslog.RFC5424)
+	server.SetHandler(handler)
+	server.ListenTCP("0.0.0.0:" + os.Getenv("PORT"))
 
-    server := syslog.NewServer()
-    server.SetFormat(syslog.RFC5424)
-    server.SetHandler(handler)
-    server.ListenTCP("0.0.0.0:" + os.Getenv("PORT"))
+	server.Boot()
 
-    server.Boot()
+	err = initDB()
+	if err != nil {
+		fmt.Println("Error establishing database connection: " + err.Error())
+		return
+	}
 
-    re, _ := regexp.Compile(`(measure|count|sample)#(\S*)=([0-9\.]+)(\S*)`)
-    tagsRe, _ := regexp.Compile(` tag#(\S*)=(\S*)`)
-    go func(channel syslog.LogPartsChannel) {
-        for logParts := range channel {
-            message, _ := logParts["message"].(string)
-            if strings.Contains(message, "v-user-client-metrics") {
-                  continue
-            }
-            t := make(map[string]string)
-            t["app"] = logParts["hostname"].(string)
-            measurements := re.FindAllStringSubmatch(message, -1)
-            tags := tagsRe.FindAllStringSubmatch(message, -1)
-            for _, v := range measurements {
-                var finalval string
-                finalval = v[3]
-                if v[4] == "MB" && strings.Contains(message, "[metrics]") {
-                    val, err := strconv.ParseFloat(v[3], 64)
-                    if err != nil {
-                        fmt.Println(err)
-                    }
-                    finalval = strconv.FormatFloat(val*1048576, 'f', -1, 64)
-                } else if v[4] == "GB" && strings.Contains(message, "[metrics]") {
-                    val, err := strconv.ParseFloat(v[3], 64)
-                    if err != nil {
-                        fmt.Println(err)
-                    }
-                    finalval = strconv.FormatFloat(val*1073741824, 'f', -1, 64)
-                } else if v[4] == "KB" && strings.Contains(message, "[metrics]") {
-                    val, err := strconv.ParseFloat(v[3], 64)
-                    if err != nil {
-                        fmt.Println(err)
-                    }
-                    finalval = strconv.FormatFloat(val*1024, 'f', -1, 64)
-                } else {
-                    finalval = v[3]
-                }
-                for _, tag := range tags {
-                    t[tag[1]] = tag[2]
-                }
-                t["metric"] = v[2]
-                value, _ := strconv.ParseFloat(finalval, 64)
-                fields := map[string]interface{}{
-                    "value": value,
-                }
-                tsdbmetric := v[1] + "." + t["metric"]
-                tsdbtags := "app=" + t["app"]
-                for _, tagelement := range tags {
-                    tsdbtags = tsdbtags + " " + tagelement[1] + "=" + tagelement[2]
-                }
-                tsdbvalue := fields["value"].(float64)
-                s := strconv.FormatFloat(tsdbvalue, 'f', -1, 64)
-                timestamp := strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10)
-                put := "put " + tsdbmetric + " " + timestamp + " " + s + " " + tsdbtags + "\n"
-                if os.Getenv("DEBUG")=="true" {
-                    fmt.Println(put)
-                }
-                fmt.Fprintf(conn, put)
-            }
-        }
-    }(channel)
+	if os.Getenv("UNIQUE_METRIC_LIMIT") != "" {
+		limit, err := strconv.ParseInt(os.Getenv("UNIQUE_METRIC_LIMIT"), 10, 0)
+		if err != nil {
+			uniqueMetricLimit = defaultMetricLimit
+		} else {
+			uniqueMetricLimit = int(limit)
+		}
+	}
 
-    server.Wait()
+	re, _ := regexp.Compile(`(measure|count|sample)#(\S*)=([0-9\.]+)(\S*)`)
+	tagsRe, _ := regexp.Compile(` tag#(\S*)=(\S*)`)
 
+	go func(channel syslog.LogPartsChannel) {
+		for logParts := range channel {
+			message, _ := logParts["message"].(string)
+			if strings.Contains(message, "v-user-client-metrics") {
+				continue
+			}
+
+			t := make(map[string]string)
+			t["app"] = logParts["hostname"].(string)
+
+			measurements := re.FindAllStringSubmatch(message, -1)
+			tags := tagsRe.FindAllStringSubmatch(message, -1)
+
+			for _, v := range measurements {
+				t["metric"] = v[2]
+				ok := checkMetric(t["app"], t["metric"])
+				if ok {
+					sendMetric(v, t, message, tags)
+				}
+			}
+		}
+	}(channel)
+
+	server.Wait()
 }


### PR DESCRIPTION
Akkeris apps have been creating insane number of custom metric types. This will keep track of how many each app has created, and prevent new ones from being created if too many currently exist.

Also a README has been added with some examples and info on requirements.

IMPORTANT NOTE: Dependency changes-
- Postgres database **REQUIRED**
- `DATABASE_URL` environment variable **REQUIRED**
- `UNIQUE_METRIC_LIMIT` environment variable *Optional* (default 100)